### PR TITLE
add uniq IP restrictions

### DIFF
--- a/anti-spam-sql-st.conf
+++ b/anti-spam-sql-st.conf
@@ -45,3 +45,8 @@ login_count_from_country_st = "SELECT login_count \
 num_countries_logs_st =       "SELECT COUNT(DISTINCT state_code) \
                                FROM postfwd_logins \
                                WHERE sasl_username=?;"
+
+
+num_ip_logs_st =       "SELECT COUNT(DISTINCT ip_address) \
+                               FROM postfwd_logins \
+                               WHERE sasl_username=?;"

--- a/anti-spam.conf
+++ b/anti-spam.conf
@@ -16,6 +16,8 @@ logfile = /tmp/postfwd_plugin.log
 debug = 1
 # Make log after exceeding unique country count limit
 country_limit = 5
+# Make log after exceeding unique ip count limit
+ip_limit = 20
 
 [app]
 # Flush database records with last login older than 1 day

--- a/postfwd-anti-spam.plugin
+++ b/postfwd-anti-spam.plugin
@@ -233,6 +233,64 @@ my $last_cache_flush = time();
 
    },
 
+   "client_uniq_ip_login_count" => sub {
+
+      my(%request) = @_;
+      my(%result) = ();
+      $result{client_ip_login_count} = 0;
+
+      # Test if database connection is still alive
+      my $rc = $dbh->ping;
+      if ( !$rc ) {
+         mylog_info("Database connection dropped (rc=$rc). Reconnecting to database.");
+         $dbh = DBI->connect_cached($dsn, $config{database}{userid}, $config{database}{password}, \%attr) or mylog_fatal ($DBI::errstr);
+      }
+
+      # Get sasl_username
+      my $user = $request{sasl_username};
+      if ( !length $user || !($user) ) {
+         return %result;
+      }
+
+      # Check if user with given IP already has record
+      my $check_user_existence_sth = $dbh->prepare($config_sql{check_user_existence_st})   or do { mylog_err($dbh->errstr); return %result; };
+      my $rowCount = $check_user_existence_sth->execute($user);
+      if ( $rowCount == 0 ) {
+         if ( $check_user_existence_sth->err ) {
+            mylog_err ($check_user_existence_sth->errstr);
+         }
+         return %result;
+      }
+
+      # Get number of unique IPs from which has user logged in
+      my $num_ip_logs_sth = $dbh->prepare($config_sql{num_ip_logs_st})       or do { mylog_err($dbh->errstr); return %result; };
+      if ( !($num_ip_logs_sth->execute($user)) ) {
+         mylog_err ($num_ip_logs_sth->errstr);
+         return %result;
+      }
+
+      # Get first row of data
+      $result{client_uniq_ip_login_count} = $num_ip_logs_sth->fetchrow_array;
+      if ( !$result{client_uniq_ip_login_count} ) {
+         if ( $num_ip_logs_sth->err ) {
+            mylog_err ($num_ip_logs_sth->errstr);
+         }
+         return %result;
+      }
+
+      # Print unique number of IPs that user was logged in from
+      if ( $result{client_uniq_ip_login_count} > $config{debugging}{ip_limit} ) {
+         mylog_info ("User $user was logged from more than $config{debugging}{ip_limit} ips($result{client_uniq_ip_login_count})");
+      }
+      else {
+         mylog_info ("Number of unique IPs logged in from user [$user]: $result{client_uniq_ip_login_count}");
+      }
+
+      # Returns number of IPs from which user logged in to an email via sasl
+      return %result;
+
+   },
+
 );
 
 1;


### PR DESCRIPTION
We have blocked several SPAM botnets with this plugin. In addition to the **client_uniq_country_login_count** we added the **client_uniq_ip_login_count**  filter.  This makes this plugin more efficient to protect against smaller/single country bots. 

postfwd configuration: 
```
id=ban_botnet_max_uniq_ip
  sasl_username=~^(.+)$
  client_uniq_ip_login_count > 20
  action=rate(sasl_username/1/10800/421 4.7.1: $$sasl_username: too many messages from different IP addresses, try later.)
```