### PR TITLE
Allow custom path to main configuration files

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,8 @@ id=BAN_BOTNET ; \
 
 Update configuration file `/etc/postfix/anti-spam.conf` with your credentials to selected database backend (tested with MySQL/PostgreSQL). Don't forget to use proper driver and port.
 
+In case you use different path as `/etc/postfix/anti-spam.conf` and `/etc/postfix/anti-spam-sql-st.conf` to main configuration file, export environment variables `POSTFWD_ANTISPAM_MAIN_CONFIG_PATH` and `POSTFWD_ANTISPAM_SQL_STATEMENTS_CONFIG_PATH` with your custom path.
+
 ```INI
 [database]
 # driver = Pg

--- a/postfwd-anti-spam.plugin
+++ b/postfwd-anti-spam.plugin
@@ -11,14 +11,26 @@ use DBI;
 use IO::Handle;
 use Time::Piece;
 
+# Configure default path to configuration files
+# or read them from environment variables
+my $cfg_anti_spam_path = "/etc/postfix/anti-spam.conf"
+my $cfg_sql_statements_path = "/etc/postfix/anti-spam-sql-st.conf"
+
+if ( !$ENV{'POSTFWD_ANTISPAM_MAIN_CONFIG_PATH'} ) {
+  $cfg_anti_spam_path = $ENV{'POSTFWD_ANTISPAM_MAIN_CONFIG_PATH'}
+}
+if ( !$ENV{'POSTFWD_ANTISPAM_SQL_STATEMENTS_CONFIG_PATH'} ) {
+  $cfg_sql_statements_path = $ENV{'POSTFWD_ANTISPAM_SQL_STATEMENTS_CONFIG_PATH'}
+}
+
 # Main config file
 use Config::Any::INI;
-my $config_ref = Config::Any::INI->load( "/etc/postfix/anti-spam.conf" );
+my $config_ref = Config::Any::INI->load( $cfg_anti_spam_path );
 my %config = %$config_ref;
 
 # SQL statements config file
 use Config::Any::General;
-my $config_sql_ref = Config::Any::General->load( "/etc/postfix/anti-spam-sql-st.conf" );
+my $config_sql_ref = Config::Any::General->load( $cfg_sql_statements_path );
 my %config_sql = %$config_sql_ref;
 
 # Logging


### PR DESCRIPTION
In order to allow setting of different location of main configuration
files, implement customization via environment variables.

This is important, if we want for example have all configuration files in
`/etc/postfwd/` directory.

closes #15 

Signed-off-by: Ondrej Vasko <ondrej.vaskoo@gmail.com>