### PR TITLE
Allow logging to STDOUT

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ apt-get install -y libgeo-ip-perl \
 
 ## Configuration
 
+Plugin configuration file `anti-spam.conf` is INI style configuration file, in which values must NOT be quoted!
+
 ### Postfwd configuration
 
 Add following rules to postfwd configuration file `postfwd.cf`. You can use your own message and value of parameter `client_uniq_country_login_count`, which sets maximum number of unique countries to allow user to log in via sasl.
@@ -143,10 +145,15 @@ db_flush_interval = 86400
 
 ## Logging
 
-By default logging for debugging purposes is enabled. Log file is by default located in `/tmp/postfwd_plugin.log` but can be changed as in example below. You can disable logging by updating configuration file.
+Plugin is by default logging into standard output. This can be changed in configuration file by setting value for statement `logfile` in `[logging]` section.
+
+You can disable logging completely by updating value of statement `debug` to `0` in section `[debugging]`.
+
+Example configuration of file `anti-spam.conf`:
 
 ```INI
 [logging]
+# Remove statement `logfile`, or set it to empty `logfile = ` to log into STDOUT
 logfile = /var/log/postfwd_plugin.log
 
 [debugging]

--- a/postfwd-anti-spam.plugin
+++ b/postfwd-anti-spam.plugin
@@ -34,14 +34,14 @@ my $config_sql_ref = Config::Any::General->load( $cfg_sql_statements_path );
 my %config_sql = %$config_sql_ref;
 
 # Logging
-open( my $log_file_fh, '>>', $config{logging}{logfile} ) or die "ERROR: Could not open file '$config{logging}{logfile}' $!\n";
-$log_file_fh->autoflush;
+my $program = "postfwd::anti-spam-plugin";
+my $log_file_fh;
 
 sub mylog {
    my ($log_level, @errstr) = @_;
    if ( $config{debugging}{debug} ) {
       my $date = localtime(time())->strftime('%F %T');
-      my $final_str = "$date $log_level: ";
+      my $final_str = "$date $program $log_level: ";
 
       foreach my $s (@errstr) {
          if ( length $s ) {
@@ -64,6 +64,16 @@ sub mylog_fatal {
    mylog("FATAL[$$]", @_);
    exit -1;
 }
+
+if ( !$config{logging}{logfile} || !length $config{logging}{logfile} || $config{logging}{logfile} eq "\"\"" || $config{logging}{logfile} eq "\'\'" ) {
+   $log_file_fh = *STDOUT;
+   mylog_info ("Logging destination is STDOUT")
+} else {
+   open( $log_file_fh, '>>', $config{logging}{logfile} ) or die "ERROR: Could not open file '$config{logging}{logfile}' $!\n";
+   $log_file_fh->autoflush;
+   mylog_info ("Logging destination is file '$config{logging}{logfile}'")
+}
+
 
 # DB connection
 # Update values to your DB connection in config file /etc/postfix/anti-spam.conf


### PR DESCRIPTION
Add program name into logging message in format <DATE PROGRAM LOG_LEVEL
MESSAGE>.

If statement `logfile` in `[logging]` section of configuration file
`anti-spam.conf` is empty, nonexistent or equal to `''` or `""`, log to
STDOUT.

Closes https://github.com/Vnet-as/postfwd-anti-geoip-spam-plugin/issues/20

Signed-off-by: Ondrej Vasko <ondrej.vaskoo@gmail.com>