### PR TITLE
Bump postfwd version to 1.39

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM postfwd/postfwd:v1.37
+FROM postfwd/postfwd:v1.39
 
 LABEL maintainer="Postfwd GeoIp Spam Plugin Maintainer <ondrej.vaskoo@gmail.com>"
 


### PR DESCRIPTION
Postfwd version tag 1.37 was removed from dockerhub.

Closes #31