### PR TITLE
CI: Create integration test using GitHub Actions

### DIFF
--- a/.github/workflows/docker-compose-integration-test.yml
+++ b/.github/workflows/docker-compose-integration-test.yml
@@ -38,7 +38,7 @@ jobs:
                             --build
                             -d
       - name: run integration tests
-        run: ./integration-compose-test.sh
+        run: ./tests/integration-compose-test.sh
       - name: read test logs
         run: docker-compose -f tests/dev-compose-postgresql.yml logs postfwd-geoip-antispam
       - name: docker-compose down
@@ -56,7 +56,7 @@ jobs:
                             --build
                             -d
       - name: run integration tests
-        run: ./integration-compose-test.sh
+        run: ./tests/integration-compose-test.sh
       - name: read test logs
         run: docker-compose -f tests/dev-compose-mysql.yml logs postfwd-geoip-antispam
       - name: docker-compose down

--- a/.github/workflows/docker-compose-integration-test.yml
+++ b/.github/workflows/docker-compose-integration-test.yml
@@ -1,0 +1,65 @@
+---
+name: docker-compose integration tests
+
+on: [push]
+
+env:
+  RUN_COMPOSE: "0"
+
+jobs:
+  lint:
+    name: "perl v${{ matrix.perl-version }}"
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        perl-version: [ '5.32', '5.30', '5.28' ]
+    container:
+      image: perldocker/perl-tester:${{ matrix.perl-version }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install dependencies
+        uses: perl-actions/install-with-cpanm@v1
+        with:
+          cpanfile: "cpanfile"
+          sudo: false
+      - name: Lint with perlcritic
+        continue-on-error: true
+        run: perlcritic postfwd-anti-spam.plugin
+
+  integration-test-postgresql:
+    runs-on: ubuntu-latest
+    env:
+      RUN_COMPOSE: "0"
+      DATABASES: "postgresql"
+    steps:
+      - uses: actions/checkout@v2
+      - name: docker-compose up
+        run: docker-compose -f tests/dev-compose-postgresql.yml
+                            up
+                            --build
+                            -d
+      - name: run integration tests
+        run: cd tests && ./integration-compose-test.sh
+      - name: read test logs
+        run: docker-compose -f tests/dev-compose-postgresql.yml logs postfwd-geoip-antispam
+      - name: docker-compose down
+        run: docker-compose -f tests/dev-compose-postgresql.yml down
+
+  integration-test-mysql:
+    runs-on: ubuntu-latest
+    env:
+      RUN_COMPOSE: "0"
+      DATABASES: "mysql"
+    steps:
+      - uses: actions/checkout@v2
+      - name: docker-compose up
+        run: docker-compose -f tests/dev-compose-mysql.yml
+                            up
+                            --build
+                            -d
+      - name: run integration tests
+        run: cd tests && ./integration-compose-test.sh
+      - name: read test logs
+        run: docker-compose -f tests/dev-compose-mysql.yml logs postfwd-geoip-antispam
+      - name: docker-compose down
+        run: docker-compose -f tests/dev-compose-mysql.yml down

--- a/.github/workflows/docker-compose-integration-test.yml
+++ b/.github/workflows/docker-compose-integration-test.yml
@@ -29,7 +29,6 @@ jobs:
   integration-test-postgresql:
     runs-on: ubuntu-latest
     env:
-      RUN_COMPOSE: "0"
       DATABASES: "postgresql"
     steps:
       - uses: actions/checkout@v2
@@ -48,7 +47,6 @@ jobs:
   integration-test-mysql:
     runs-on: ubuntu-latest
     env:
-      RUN_COMPOSE: "0"
       DATABASES: "mysql"
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/docker-compose-integration-test.yml
+++ b/.github/workflows/docker-compose-integration-test.yml
@@ -37,6 +37,7 @@ jobs:
                             up
                             --build
                             -d
+             && sleep 10
       - name: run integration tests
         run: ./tests/integration-compose-test.sh
       - name: read test logs
@@ -55,6 +56,7 @@ jobs:
                             up
                             --build
                             -d
+             && sleep 10
       - name: run integration tests
         run: ./tests/integration-compose-test.sh
       - name: read test logs

--- a/.github/workflows/docker-compose-integration-test.yml
+++ b/.github/workflows/docker-compose-integration-test.yml
@@ -38,7 +38,7 @@ jobs:
                             --build
                             -d
       - name: run integration tests
-        run: cd tests && ./integration-compose-test.sh
+        run: ./integration-compose-test.sh
       - name: read test logs
         run: docker-compose -f tests/dev-compose-postgresql.yml logs postfwd-geoip-antispam
       - name: docker-compose down
@@ -56,7 +56,7 @@ jobs:
                             --build
                             -d
       - name: run integration tests
-        run: cd tests && ./integration-compose-test.sh
+        run: ./integration-compose-test.sh
       - name: read test logs
         run: docker-compose -f tests/dev-compose-mysql.yml logs postfwd-geoip-antispam
       - name: docker-compose down

--- a/cpanfile
+++ b/cpanfile
@@ -1,0 +1,7 @@
+requires 'Geo::IP';
+requires 'Time::Piece';
+requires 'Config::Any';
+requires 'DBI';
+requires 'DBD::mysql';
+requires 'DBD::Pg';
+requires 'Net::Subnet';

--- a/docs/README.md
+++ b/docs/README.md
@@ -89,6 +89,10 @@ CREATE INDEX postfwd_sasl_username ON postfwd_logins (sasl_username);
 - Perl modules - `Geo::IP`, `DBI`, `Time::Piece`, `Config::Any`, `Net::Subnet`, `DBD::mysql` or `DBD::Pg`.
 - GeoIP database.
 
+#### Cpanm
+
+You can install all dependencies using cpanm with single command `cpanm --installdeps .`
+
 #### Dependencies on RedHat based distributions
 
 Install *GeoIP*, *Time*, *Config*, *DBI* and database modules with following command:

--- a/tests/dev-anti-spam-mysql.conf
+++ b/tests/dev-anti-spam-mysql.conf
@@ -1,7 +1,7 @@
 [database]
 driver = mysql
 database = postfwd_antispam_test
-host = mysql-postfwd-db
+host = 127.0.0.1
 port = 3306
 userid = testuser
 password = testpasswordpostfwdantispam

--- a/tests/dev-anti-spam-postgres.conf
+++ b/tests/dev-anti-spam-postgres.conf
@@ -1,7 +1,7 @@
 [database]
 driver = Pg
 database = postfwd_antispam_test
-host = postgres-postfwd-db
+host = 127.0.0.1
 port = 5432
 userid = testuser
 password = testpasswordpostfwdantispam

--- a/tests/dev-compose-mysql.yml
+++ b/tests/dev-compose-mysql.yml
@@ -1,5 +1,5 @@
 ---
-version: "3.3"
+version: "3.8"
 
 services:
   mysql-postfwd-db:

--- a/tests/dev-compose-mysql.yml
+++ b/tests/dev-compose-mysql.yml
@@ -1,10 +1,10 @@
 ---
 version: "3.3"
+
 services:
   mysql-postfwd-db:
+    network_mode: host
     image: mariadb:latest
-    ports:
-      - "3306:3306"
     environment:
       - MYSQL_ALLOW_EMPTY_PASSWORD=no
       - MYSQL_RANDOM_ROOT_PASSWORD=yes
@@ -16,13 +16,14 @@ services:
         source: ./dev-create-antispam-db.sql
         target: /docker-entrypoint-initdb.d/dev-create-antispam-db.sql
   postfwd-geoip-antispam:
+    network_mode: host
     build:
       context: ../
       dockerfile: docker/Dockerfile
     environment:
       - PROG=postfwd3
-    ports:
-      - "10040:10040"
+    depends_on:
+      - mysql-postfwd-db
     volumes:
       - type: bind
         source: ./dev-anti-spam-mysql.conf

--- a/tests/dev-compose-postgresql.yml
+++ b/tests/dev-compose-postgresql.yml
@@ -1,5 +1,6 @@
 ---
-version: "3.3"
+version: "3.8"
+
 services:
   postgres-postfwd-db:
     network_mode: host

--- a/tests/dev-compose-postgresql.yml
+++ b/tests/dev-compose-postgresql.yml
@@ -2,9 +2,8 @@
 version: "3.3"
 services:
   postgres-postfwd-db:
+    network_mode: host
     image: postgres:latest
-    ports:
-      - "5432:5432"
     environment:
       - POSTGRES_USER=testuser
       - POSTGRES_PASSWORD=testpasswordpostfwdantispam
@@ -14,13 +13,14 @@ services:
         source: ./dev-create-antispam-db.sql
         target: /docker-entrypoint-initdb.d/dev-create-antispam-db.sql
   postfwd-geoip-antispam:
+    network_mode: host
     build:
       context: ../
       dockerfile: docker/Dockerfile
     environment:
       - PROG=postfwd3
-    ports:
-      - "10040:10040"
+    depends_on:
+      - postgres-postfwd-db
     volumes:
       - type: bind
         source: ./dev-anti-spam-postgres.conf

--- a/tests/integration-compose-test.sh
+++ b/tests/integration-compose-test.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-script_path=$(dirname "${script_path}")
+script_path=$(dirname "${0}")
 
 function send_requests {
   local sasl_username=${1}

--- a/tests/integration-compose-test.sh
+++ b/tests/integration-compose-test.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
 script_path=$(dirname "${0}")
-set -x
 
 function send_requests {
   local sasl_username=${1}
@@ -9,7 +8,7 @@ function send_requests {
   for client_address in "${client_addresses[@]}"; do
     export SASL_USERNAME=${sasl_username}
     export CLIENT_ADDRESS=${client_address}
-    nc localhost 10040 -v -w 10 < <(envsubst < "${script_path}/dev-request") > /dev/null
+    nc 127.0.0.1 10040 -v -w 10 < <(envsubst < "${script_path}/dev-request") > /dev/null
   done
 }
 

--- a/tests/integration-compose-test.sh
+++ b/tests/integration-compose-test.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 script_path=$(dirname "${0}")
+set -x
 
 function send_requests {
   local sasl_username=${1}
@@ -8,7 +9,7 @@ function send_requests {
   for client_address in "${client_addresses[@]}"; do
     export SASL_USERNAME=${sasl_username}
     export CLIENT_ADDRESS=${client_address}
-    nc 127.0.0.1 10040 < <(envsubst < "${script_path}/dev-request") > /dev/null
+    nc localhost 10040 -v -w 10 < <(envsubst < "${script_path}/dev-request") > /dev/null
   done
 }
 

--- a/tests/integration-compose-test.sh
+++ b/tests/integration-compose-test.sh
@@ -1,11 +1,15 @@
 #!/usr/bin/env bash
 
-function send_request {
-  local client_address=${1}
-  local sasl_username=${2}
-  export CLIENT_ADDRESS=${client_address}
-  export SASL_USERNAME=${sasl_username}
-  nc 127.0.0.1 10040 < <(envsubst < dev-request)
+script_path=$(dirname "${script_path}")
+
+function send_requests {
+  local sasl_username=${1}
+  local -n client_addresses=${2}
+  for client_address in "${client_addresses[@]}"; do
+    export SASL_USERNAME=${sasl_username}
+    export CLIENT_ADDRESS=${client_address}
+    nc 127.0.0.1 10040 < <(envsubst < "${script_path}/dev-request") > /dev/null
+  done
 }
 
 sleep_duration=10
@@ -13,7 +17,7 @@ sleep_duration=10
 for DB in ${DATABASES}; do
   # Build and run compose
   if [ "${RUN_COMPOSE}" = "1" ]; then
-    docker-compose -f "dev-compose-${DB}.yml" up -d --build > /dev/null
+    docker-compose -f "${script_path}/dev-compose-${DB}.yml" up -d --build > /dev/null
     echo "Sleeping ${sleep_duration} seconds until compose initializes"
     sleep ${sleep_duration}
     echo "Sleep done"
@@ -21,79 +25,76 @@ for DB in ${DATABASES}; do
 
   # Valid user logging in with IP addresses from Slovakia and Czech Republic
   sasl_username="valid-user@example.com"
-  addresses=(5.178.48.14 31.3.32.47 46.229.224.95 46.229.230.120
-             37.48.42.15 37.48.42.229 46.13.5.5
+  valid_user_addresses=(5.178.48.14
+                        31.3.32.47
+                        46.229.224.95
+                        46.229.230.120
+                        37.48.42.15
+                        37.48.42.229
+                        46.13.5.5
   )
-
-  for client_address in "${addresses[@]}"; do
-    send_request "$client_address" "$sasl_username" > /dev/null
-  done
+  send_requests "$sasl_username" "valid_user_addresses"
 
 
   # Spam user logging in with IP addresses from 7 different countries
   # SVK, CZ, IT, NOR, CAN, KAZ, FRA
   sasl_username="spam-user1@example.com"
-  addresses=( 46.229.224.61
-              46.13.7.27
-              31.44.115.66
-              79.141.110.169
-              24.37.219.201
-              79.142.52.15
-              46.238.128.94 46.238.128.94
+  spam_user1_addresses=( 46.229.224.61
+                         46.13.7.27
+                         31.44.115.66
+                         79.141.110.169
+                         24.37.219.201
+                         79.142.52.15
+                         46.238.128.94 46.238.128.94
   )
-
-  for client_address in "${addresses[@]}"; do
-    send_request "$client_address" "$sasl_username"
-  done
+  send_requests "$sasl_username" "spam_user1_addresses"
 
 
   # Spam user logging in with 25 different IP addresses from SVK
   sasl_username="spam-user2@example.com"
-  addresses=( 213.215.64.10 213.181.128.10 213.160.160.10
-              213.151.225.10 213.151.224.10 217.75.64.10
-              217.75.80.10 217.118.96.10 193.87.0.10
-              188.123.96.10 176.116.96.10 145.255.144.10
-              94.229.32.0 93.184.64.10 91.191.64.0
-              89.173.0.10 87.244.192.10 85.237.224.10
-              84.245.64.10 84.16.32.10 81.162.80.10
-              80.242.32.10 80.86.240.10 62.176.160.10
-              62.152.224.0
+  spam_user2_addresses=( 213.215.64.10 213.181.128.10 213.160.160.10
+                         213.151.225.10 213.151.224.10 217.75.64.10
+                         217.75.80.10 217.118.96.10 193.87.0.10
+                         188.123.96.10 176.116.96.10 145.255.144.10
+                         94.229.32.0 93.184.64.10 91.191.64.0
+                         89.173.0.10 87.244.192.10 85.237.224.10
+                         84.245.64.10 84.16.32.10 81.162.80.10
+                         80.242.32.10 80.86.240.10 62.176.160.10
+                         62.152.224.0
   )
-
-  for client_address in "${addresses[@]}"; do
-    send_request "$client_address" "$sasl_username"
-  done
+  send_requests "$sasl_username" "spam_user2_addresses"
 
 
   # Verify logs
-  #   1. Check for rrors
+  #   1. Check for errors
   #   2. Check if spam-user exceeded country limit
-  #   2. Check if spam-user exceeded IP address limit
-  if docker-compose -f "dev-compose-${DB}.yml" logs postfwd-geoip-antispam \
+  #   3. Check if spam-user exceeded IP address limit
+  declare -a errors
+  if docker-compose -f "${script_path}/dev-compose-${DB}.yml" logs postfwd-geoip-antispam \
      | grep -i "error\|fatal" \
      | grep -E -v -e "ERROR.*: Retry [123]/3 - Can't connect to MySQL server on" \
                   -e "ERROR.*: Retry [123]/3 - could not connect to server: Connection refused"; then
     echo -e 'ERROR: Errors found in log.\nTEST FAILED!'
-    ERR="${ERR},1"
+    errors+=("1")
   fi
-  if ! docker-compose -f "dev-compose-${DB}.yml" logs postfwd-geoip-antispam \
+  if ! docker-compose -f "${script_path}/dev-compose-${DB}.yml" logs postfwd-geoip-antispam \
        | grep "User spam-user1@example.com was logged from more than 5 countries([67])"; then
     echo -e 'ERROR: User did not exceed country login limit (5) but should!'
-    ERR="${ERR},2"
+    errors+=("2")
   fi
-  if ! docker-compose -f "dev-compose-${DB}.yml" logs postfwd-geoip-antispam \
+  if ! docker-compose -f "${script_path}/dev-compose-${DB}.yml" logs postfwd-geoip-antispam \
        | grep "User spam-user2@example.com was logged from more than 20 IP addresses(2[45])"; then
     echo -e 'ERROR: User did not exceed IP address limit (20) but should!'
-    ERR="${ERR},3"
+    errors+=("3")
   fi
 
   # Cleanup
   if [ "${RUN_COMPOSE}" = "1" ]; then
-    docker-compose -f "dev-compose-${DB}.yml" down > /dev/null
+    docker-compose -f "${script_path}/dev-compose-${DB}.yml" down > /dev/null
   fi
 done
 
-if [ -n "$ERR" ]; then
-  echo "Tests ended up with errors[${ERR}]."
+if [ "${#errors[@]}" -gt 0 ]; then
+  echo "Tests ended up with errors[${errors[*]}]."
   exit 1
 fi


### PR DESCRIPTION
Implement CI using GitHub Actions:

- Add static lint with perlcritic
- Add options to install dependencies from cpanfile
- Use docker-compose similar as for local testing
- Reaching port 10040 from host doesn't work with docker network so far. Use `host` network and try to revisit it again soon.
- Improve testing script to be runnable from different directory
- Improve error report in testing script
- Closes https://github.com/Vnet-as/postfwd-anti-geoip-spam-plugin/issues/28

Signed-off-by: Ondrej Vasko <ondrej.vaskoo@gmail.com>