### PR TITLE
Logging limits

### DIFF
--- a/conf/anti-spam.conf
+++ b/conf/anti-spam.conf
@@ -9,12 +9,10 @@ userid = testuser
 password = password
 
 [logging]
+# Enable(1) or disable(0) logging
+enable = 1
 logfile = /tmp/postfwd_plugin.log
 autoflush = 0
-
-[debugging]
-# Enable(1) or disable(0) logging
-debug = 1
 # Make log after exceeding unique country count limit
 country_limit = 5
 # Make log after exceeding unique ip count limit

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -27,6 +27,7 @@ RUN    apk --no-cache update \
              Config::Tiny \
              Config::Any::INI \
              Config::Any::General \
+             Readonly \
              DBI \
              DBD::Pg \
              DBD::mysql \

--- a/docker/README.md
+++ b/docker/README.md
@@ -57,12 +57,10 @@ userid = testuser
 password = testpasswordpostfwdantispam
 
 [logging]
+# Enable(1) or disable(0) logging
+enable = 1
 # logfile =
 autoflush = 1
-
-[debugging]
-# Enable(1) or disable(0) logging
-debug = 1
 # Make log after exceeding unique country count limit
 country_limit = 5
 # Make log after exceeding unique ip count limit

--- a/docs/README.md
+++ b/docs/README.md
@@ -203,17 +203,15 @@ ip_whitelist = 198.51.100.0/24,203.0.113.123/32
 
 Plugin is by default logging into standard output. This can be changed in configuration file by setting value for `logging.logfile`.
 
-You can disable logging completely by updating value of statement `debugging.debug` to `0`.
+You can disable logging completely by updating value of statement `logging.enable` to `0`.
 
 ```ini
 [logging]
+# enable(1) or disable(0) logging
+enable = 1
 # remove statement `logfile`, or set it to empty `logfile = ` to log into STDOUT
 logfile = /var/log/postfwd_plugin.log
 autoflush = 0
-
-[debugging]
-# enable(1) or disable(0) logging
-debug = 1
 # make log after exceeding unique country count limit
 country_limit = 5
 # make log after exceeding unique ip count limit

--- a/docs/README.md
+++ b/docs/README.md
@@ -111,7 +111,8 @@ yum install -y 'perl(Geo::IP)' \
                'perl(IO::Socket::SSL)' \
                'perl(LWP::Protocol::https)' \
                'perl(Class::XSAccessor)' \
-               'perl(MaxMind::DB::Reader::XS)'
+               'perl(MaxMind::DB::Reader::XS)' \
+               'perl(Readonly)'
 ```
 
 #### Dependencies on Debian based distributions
@@ -132,7 +133,8 @@ apt-get install -y libgeo-ip-perl \
                    liblwp-protocol-https-perl \
                    libclass-xsaccessor-perl \
                    libmaxmind-db-reader-xs-perl \
-                   libgeoip2-perl
+                   libgeoip2-perl \
+                   libreadonly-perl
 ```
 
 ## Configuration

--- a/postfwd-anti-spam.plugin
+++ b/postfwd-anti-spam.plugin
@@ -241,10 +241,24 @@ sub geoip_country_code {
     }
 
     if ($geoip_db_version == 2) {
-        my $country = eval { $gi->country( ip => $client_ip ) };
+        my $country = eval {
+            $gi->country( ip => $client_ip );
+        };
         if ( $EVAL_ERROR ) {
-            if ($EVAL_ERROR =~ m/No record found for IP addresds/ims ) {
-                mylog_info("Cannot find country code for IP address [$client_ip]");
+            if ($EVAL_ERROR =~ m/No record found for IP address/ims ) {
+                mylog_info("Cannot find IP address in GeoIP database [$client_ip]");
+                return;
+            }
+            if ($EVAL_ERROR =~ m/The IP address you provided (.*) is not a public IP address/ims ) {
+                mylog_info("IP address is not public [$client_ip]");
+                return;
+            }
+            if ($EVAL_ERROR =~ m/is not a valid IP/ims ) {
+                mylog_info("Invalid IP address [$client_ip]");
+                return;
+            }
+            if ($EVAL_ERROR =~ m/The IP address you provided (.*) is not a valid IPv4/ims ) {
+                mylog_info("Invalid IP address [$client_ip]");
                 return;
             }
         }

--- a/postfwd-anti-spam.plugin
+++ b/postfwd-anti-spam.plugin
@@ -206,7 +206,7 @@ sub get_geoip_version {
     } else {
         $gi = $gi_v2;
         mylog_info('[GeoIP2] Description: ', $gi_v2_metadata->description()->{en});
-        mylog_info('[GeoIP2] Database Edition: ', $gi_v2_metadata->binary_format_major_version().$gi_v2_metadata->binary_format_minor_version());
+        mylog_info('[GeoIP2] Database Edition: ', $gi_v2_metadata->binary_format_major_version(), '.', $gi_v2_metadata->binary_format_minor_version());
         mylog_info('[GeoIP2] Database Type: ', $gi_v2_metadata->database_type());
         mylog_info('[GeoIP2] Build: ', $gi_v2_metadata->build_epoch());
         mylog_info('[GeoIP2] IP Version: ', $gi_v2_metadata->ip_version());

--- a/postfwd-anti-spam.plugin
+++ b/postfwd-anti-spam.plugin
@@ -97,17 +97,19 @@ sub mylog_fatal {
 }
 
 sub log_uniq_ip_spam {
-    my ($uniq_ip_login_count, $user) = (@_);
+    my ($uniq_ip_login_count, $user) = @_;
     if ($uniq_ip_login_count > $logging_ip_limit ) {
         mylog_info("User $user was logged from more than $logging_ip_limit IP addresses($uniq_ip_login_count)");
     }
+    return;
 }
 
 sub log_uniq_country_spam {
-    my ($uniq_country_login_count, $user) = (@_);
+    my ($uniq_country_login_count, $user) = @_;
     if ($uniq_country_login_count > $logging_country_limit ) {
         mylog_info("User $user was logged from more than $logging_country_limit countries($uniq_country_login_count)");
     }
+    return;
 }
 
 

--- a/postfwd-anti-spam.plugin
+++ b/postfwd-anti-spam.plugin
@@ -34,6 +34,17 @@ use Config::Any::INI;
 my $config_ref = Config::Any::INI->load($cfg_anti_spam_path);
 my %config     = %{$config_ref};
 
+# Set unique IP and Country limit for logging
+my $logging_ip_limit = 25;
+my $logging_country_limit = 5;
+
+if ( $config{debugging}{ip_limit} ) {
+    $logging_ip_limit = $config{debugging}{ip_limit};
+}
+if ( $config{debugging}{country_limit} ) {
+    $logging_country_limit = $config{debugging}{country_limit};
+}
+
 # SQL statements config file
 use Config::Any::General;
 my $config_sql_ref = Config::Any::General->load($cfg_sql_statements_path);
@@ -77,6 +88,21 @@ sub mylog_fatal {
     mylog( "FATAL[$PID]", @args );
     exit 1;
 }
+
+sub log_uniq_ip_spam {
+    my ($uniq_ip_login_count, $user) = (@_);
+    if ($uniq_ip_login_count > $logging_ip_limit ) {
+        mylog_info("User $user was logged from more than $logging_ip_limit IP addresses($uniq_ip_login_count)");
+    }
+}
+
+sub log_uniq_country_spam {
+    my ($uniq_country_login_count, $user) = (@_);
+    if ($uniq_country_login_count > $logging_country_limit ) {
+        mylog_info("User $user was logged from more than $logging_country_limit countries($uniq_country_login_count)");
+    }
+}
+
 
 if (   !$config{logging}{logfile}
     || !length $config{logging}{logfile}
@@ -458,13 +484,7 @@ my $last_cache_flush = time;
         mylog_info(
 "Number of unique countries logged in from user [$user]: $result->{client_uniq_country_login_count}"
         );
-        if ( $result->{client_uniq_country_login_count} >
-            $config{debugging}{country_limit} )
-        {
-            mylog_info(
-"User $user was logged from more than $config{debugging}{country_limit} countries($result->{client_uniq_country_login_count})"
-            );
-        }
+        log_uniq_country_spam($results->{client_uniq_country_login_count}, $user);
 
         # Returns number of countries from which user logged in to an email via sasl
         return $result;
@@ -529,13 +549,7 @@ my $last_cache_flush = time;
         mylog_info(
 "Number of unique IPs logged in from user [$user]: $result->{client_uniq_ip_login_count}"
         );
-        if (
-            $result->{client_uniq_ip_login_count} > $config{debugging}{ip_limit} )
-        {
-            mylog_info(
-"User $user was logged from more than $config{debugging}{ip_limit} IP addresses($result->{client_uniq_ip_login_count})"
-            );
-        }
+        log_uniq_ip_spam($results->{client_uniq_ip_login_count}, $user);
 
         # Returns number of IPs from which user logged in to an email via sasl
         return $result;

--- a/postfwd-anti-spam.plugin
+++ b/postfwd-anti-spam.plugin
@@ -38,11 +38,11 @@ my %config     = %{$config_ref};
 my $logging_ip_limit = 20;
 my $logging_country_limit = 5;
 
-if ( $config{debugging}{ip_limit} ) {
-    $logging_ip_limit = $config{debugging}{ip_limit};
+if ( $config{logging}{ip_limit} ) {
+    $logging_ip_limit = $config{logging}{ip_limit};
 }
-if ( $config{debugging}{country_limit} ) {
-    $logging_country_limit = $config{debugging}{country_limit};
+if ( $config{logging}{country_limit} ) {
+    $logging_country_limit = $config{logging}{country_limit};
 }
 
 # SQL statements config file
@@ -56,7 +56,7 @@ my $log_file_fh;
 
 sub mylog {
     my ( $log_level, @errstr ) = @_;
-    if ( $config{debugging}{debug} ) {
+    if ( $config{logging}{enable} ) {
         my $date      = localtime(time)->strftime('%F %T');
         my $final_str = "$date $program $log_level: ";
 

--- a/postfwd-anti-spam.plugin
+++ b/postfwd-anti-spam.plugin
@@ -35,7 +35,7 @@ my $config_ref = Config::Any::INI->load($cfg_anti_spam_path);
 my %config     = %{$config_ref};
 
 # Set unique IP and Country limit for logging
-my $logging_ip_limit = 25;
+my $logging_ip_limit = 20;
 my $logging_country_limit = 5;
 
 if ( $config{debugging}{ip_limit} ) {

--- a/postfwd-anti-spam.plugin
+++ b/postfwd-anti-spam.plugin
@@ -368,7 +368,7 @@ my $last_cache_flush = time;
         # Simple regex test if string looks like IP address
         if ( !( $client_ip =~ m/^\d{1,3}[.]\d{1,3}[.]\d{1,3}[.]\d{1,3}$/msx ) )
         {
-            mylog_info("'$client_ip' is not valid IP address");
+            mylog_info("'$client_ip' is not a valid IP address");
             return $result;
         }
 

--- a/postfwd-anti-spam.plugin
+++ b/postfwd-anti-spam.plugin
@@ -6,6 +6,9 @@ our $VERSION = '1.50.0';
 # English module for Perl::Critic compliance
 use English qw( -no_match_vars );
 
+# For constants
+use Readonly;
+
 # DBI
 use DBI;
 
@@ -35,14 +38,18 @@ my $config_ref = Config::Any::INI->load($cfg_anti_spam_path);
 my %config     = %{$config_ref};
 
 # Set unique IP and Country limit for logging
-my $logging_ip_limit = 20;
-my $logging_country_limit = 5;
+my $LOGGING_IP_LIMIT;
+my $LOGGING_COUNTRY_LIMIT;
 
 if ( $config{logging}{ip_limit} ) {
-    $logging_ip_limit = $config{logging}{ip_limit};
+    Readonly $LOGGING_IP_LIMIT => $config{logging}{ip_limit};
+} else {
+    Readonly $LOGGING_IP_LIMIT => 20;
 }
 if ( $config{logging}{country_limit} ) {
-    $logging_country_limit = $config{logging}{country_limit};
+    Readonly $LOGGING_COUNTRY_LIMIT => $config{logging}{country_limit};
+} else {
+    Readonly $LOGGING_COUNTRY_LIMIT => 5;
 }
 
 # SQL statements config file
@@ -260,16 +267,16 @@ my %attr = ( RaiseError => 0, PrintError => 1, AutoCommit => 1 );
 mylog_info("Starting postfwd plugin with dsn '$dsn'");
 
 # Connect to DB, do 3 retries with 10 second timeout
-use constant DB_CONN_RETRIES => 3;
-use constant DB_CONN_TIMEOUT => 10;
-for ( 1 .. DB_CONN_RETRIES ) {
+Readonly my $DB_CONN_RETRIES => 3;
+Readonly my $DB_CONN_TIMEOUT => 10;
+for ( 1 .. $DB_CONN_RETRIES ) {
     $dbh = DBI->connect(
         $dsn,
         $config{database}{userid},
         $config{database}{password}, \%attr
     ) and last;
     mylog_err( 'Retry ', $_, '/3', ' - ', DBI->errstr );
-    sleep DB_CONN_TIMEOUT;
+    sleep $DB_CONN_TIMEOUT;
 }
 if ( !defined $dbh ) {
     mylog_fatal 'Could not connect to configured database after 3 retries';

--- a/postfwd-anti-spam.plugin
+++ b/postfwd-anti-spam.plugin
@@ -98,16 +98,16 @@ sub mylog_fatal {
 
 sub log_uniq_ip_spam {
     my ($uniq_ip_login_count, $user) = @_;
-    if ($uniq_ip_login_count > $logging_ip_limit ) {
-        mylog_info("User $user was logged from more than $logging_ip_limit IP addresses($uniq_ip_login_count)");
+    if ($uniq_ip_login_count > $LOGGING_IP_LIMIT ) {
+        mylog_info("User $user was logged from more than $LOGGING_IP_LIMIT IP addresses($uniq_ip_login_count)");
     }
     return;
 }
 
 sub log_uniq_country_spam {
     my ($uniq_country_login_count, $user) = @_;
-    if ($uniq_country_login_count > $logging_country_limit ) {
-        mylog_info("User $user was logged from more than $logging_country_limit countries($uniq_country_login_count)");
+    if ($uniq_country_login_count > $LOGGING_COUNTRY_LIMIT ) {
+        mylog_info("User $user was logged from more than $LOGGING_COUNTRY_LIMIT countries($uniq_country_login_count)");
     }
     return;
 }

--- a/postfwd-anti-spam.plugin
+++ b/postfwd-anti-spam.plugin
@@ -493,7 +493,7 @@ my $last_cache_flush = time;
         mylog_info(
 "Number of unique countries logged in from user [$user]: $result->{client_uniq_country_login_count}"
         );
-        log_uniq_country_spam($results->{client_uniq_country_login_count}, $user);
+        log_uniq_country_spam($result->{client_uniq_country_login_count}, $user);
 
         # Returns number of countries from which user logged in to an email via sasl
         return $result;
@@ -558,7 +558,7 @@ my $last_cache_flush = time;
         mylog_info(
 "Number of unique IPs logged in from user [$user]: $result->{client_uniq_ip_login_count}"
         );
-        log_uniq_ip_spam($results->{client_uniq_ip_login_count}, $user);
+        log_uniq_ip_spam($result->{client_uniq_ip_login_count}, $user);
 
         # Returns number of IPs from which user logged in to an email via sasl
         return $result;

--- a/tests/01-dev-anti-spam-mysql-geoip1.conf
+++ b/tests/01-dev-anti-spam-mysql-geoip1.conf
@@ -7,12 +7,10 @@ userid = testuser
 password = testpasswordpostfwdantispam
 
 [logging]
+# Enable(1) or disable(0) logging
+enable = 1
 # logfile =
 autoflush = 1
-
-[debugging]
-# Enable(1) or disable(0) logging
-debug = 1
 # Make log after exceeding unique country count limit
 country_limit = 5
 # Make log after exceeding unique ip count limit

--- a/tests/02-dev-anti-spam-postgres-geoip1.conf
+++ b/tests/02-dev-anti-spam-postgres-geoip1.conf
@@ -7,12 +7,10 @@ userid = testuser
 password = testpasswordpostfwdantispam
 
 [logging]
+# Enable(1) or disable(0) logging
+enable = 1
 # logfile =
 autoflush = 1
-
-[debugging]
-# Enable(1) or disable(0) logging
-debug = 1
 # Make log after exceeding unique country count limit
 country_limit = 5
 # Make log after exceeding unique ip count limit

--- a/tests/03-dev-anti-spam-mysql-geoip2.conf
+++ b/tests/03-dev-anti-spam-mysql-geoip2.conf
@@ -7,12 +7,10 @@ userid = testuser
 password = testpasswordpostfwdantispam
 
 [logging]
+# Enable(1) or disable(0) logging
+enable = 1
 # logfile =
 autoflush = 1
-
-[debugging]
-# Enable(1) or disable(0) logging
-debug = 1
 # Make log after exceeding unique country count limit
 country_limit = 5
 # Make log after exceeding unique ip count limit

--- a/tests/04-dev-anti-spam-mysql-no-geoip.conf
+++ b/tests/04-dev-anti-spam-mysql-no-geoip.conf
@@ -7,12 +7,10 @@ userid = testuser
 password = testpasswordpostfwdantispam
 
 [logging]
+# Enable(1) or disable(0) logging
+enable = 1
 # logfile =
 autoflush = 1
-
-[debugging]
-# Enable(1) or disable(0) logging
-debug = 1
 # Make log after exceeding unique country count limit
 country_limit = 5
 # Make log after exceeding unique ip count limit

--- a/tests/integration-compose-test-geoip1.sh
+++ b/tests/integration-compose-test-geoip1.sh
@@ -36,6 +36,26 @@ for DB in ${DATABASES}; do
   send_requests "$sasl_username" "valid_user_addresses"
 
 
+  # User logging from IP addresses which are not in DB
+  sasl_username="valid-user-non-existing-ip@example.com"
+  valid_user_non_existing_ip_addresses=(192.168.35.1
+                                        10.1.1.1
+                                        172.20.20.20
+                                        192.0.2.15
+  )
+  send_requests "$sasl_username" "valid_user_non_existing_ip_addresses"
+
+
+  # User logging from invalid IP addresses
+  sasl_username="valid-user-non-existing-ip@example.com"
+  valid_user_invalid_ips=(my-special-ip
+                          10123.1.1.1
+                          172.20.20.20:1234
+                          500.0.2.15
+  )
+  send_requests "$sasl_username" "valid_user_invalid_ips"
+
+
   # Spam user logging in with IP addresses from 7 different countries
   # SVK, CZ, IT, NOR, CAN, KAZ, FRA
   sasl_username="spam-user1@example.com"

--- a/tests/integration-compose-test-geoip2.sh
+++ b/tests/integration-compose-test-geoip2.sh
@@ -82,7 +82,10 @@ declare -a errors
 if docker-compose -f "${script_path}/compose-dev-mysql.yml" logs postfwd-geoip-antispam \
    | grep -i "error\|fatal" \
    | grep -E -v -e "ERROR.*: Retry [123]/3 - Can't connect to MySQL server on" \
-                -e "ERROR.*: Retry [123]/3 - could not connect to server: Connection refused"; then
+                -e "ERROR.*: Retry [123]/3 - could not connect to server: Connection refused" \
+   | grep -E -v -e "\[postfwd3/policy\]\[[[:digit:]]+\]\[LOG crit\]: FATAL: The IP address you provided.*is not a valid IPv4 or IPv6 address" \
+                -e "\[postfwd3/policy\]\[[[:digit:]]+\]\[LOG crit\]: FATAL: The IP address you provided.*is not a public IP address" \
+                -e "\[postfwd3/policy\]\[[[:digit:]]+\]\[LOG crit\]: FATAL: No record found for IP address"; then
   echo -e 'ERROR: Errors found in log.\nTEST FAILED!'
   errors+=("1")
 fi

--- a/tests/integration-compose-test-geoip2.sh
+++ b/tests/integration-compose-test-geoip2.sh
@@ -25,6 +25,26 @@ valid_user_addresses=( 2.125.160.216
 send_requests "$sasl_username" "valid_user_addresses"
 
 
+# User logging from IP addresses which are not in DB
+sasl_username="valid-user-non-existing-ip@example.com"
+valid_user_non_existing_ip_addresses=(192.168.35.1
+                                      10.1.1.1
+                                      172.20.20.20
+                                      192.0.2.15
+)
+send_requests "$sasl_username" "valid_user_non_existing_ip_addresses"
+
+
+# User logging from invalid IP addresses
+sasl_username="valid-user-non-existing-ip@example.com"
+valid_user_invalid_ips=(my-special-ip
+                        10123.1.1.1
+                        172.20.20.20:1234
+                        500.0.2.15
+)
+send_requests "$sasl_username" "valid_user_invalid_ips"
+
+
 # Spam user logging in with IP addresses from 7 different countries
 # UK, US, BT, SE, CN, PH, GI
 sasl_username="spam-user1@example.com"


### PR DESCRIPTION
Remove section `debugging` from config file and replace it with these options:
- `logging.enable`
- `logging.ip_limit`
- `logging.country_limit`

Use Readonly for constants to mitigate perlcritic warnings.

New tests discovered errors with GeoIP2 database module:

```bash
postfwd-geoip-antispam_1  | [postfwd3/policy][10][LOG crit]: FATAL: The IP address you provided (192.168.35.1) is not a public IP address when calling GeoIP2::Database::Reader::country on GeoIP2::Database::Reader??Trace begun at /usr/local/share/perl5/site_perl/GeoIP2/Database/Reader.pm line 81?GeoIP2::Database::Reader::_model_for_address('GeoIP2::Database::Reader=HASH(0x555e9ec3f3e0)', 'Country', 'type_check', 'Regexp=REGEXP(0x555e9ef32710)', 'ip', 192.168.35.1) called at /usr/local/share/perl5/site_perl/GeoIP2/Database/Reader.pm line 133?GeoIP2::Database::Reader::country('GeoIP2::Database::Reader=HASH(0x555e9ec3f3e0)', 'ip', 192.168.35.1) called at /etc/postfwd/postfwd-anti-spam.plugin line 245?eval {...} at /etc/postfwd/postfwd-anti-spam.plugin line 244?postfwd3::server::geoip_country_code(192.168.35.1) called at /etc/postfwd/postfwd-anti-spam.plugin line 376?postfwd3::server::__ANON__('HASH(0x555e9d709378)') called at /usr/sbin/postfwd3 line 1855?postfwd3::server::postfwd_items('HASH(0x555e9d709378)') called at /usr/sbin/postfwd3 line 2853?postfwd3::server::smtpd_access_policy(undef, 'HASH(0x555e9d709378)') called at /usr/sbin/postfwd3 line 3309?postfwd3::server::process_input(undef, 'Net::Server::Proto::TCP=GLOB(0x555e9ee94f58)', '', 'HASH(0x555e9d709378)') called at /usr/sbin/postfwd3 line 3292?postfwd3::server::mux_input('Net::Server::Multiplex::MUX=HASH(0x555e9ee94dd8)', 'IO::Multiplex=HASH(0x555e9ee7b728)', 'Net::Server::Proto::TCP=GLOB(0x555e9ee94f58)', 'SCALAR(0x555e9ee9c080)') called at /usr/share/perl5/vendor_perl/Net/Server/Multiplex.pm line 220?Net::Server::Multiplex::MUX::mux_input('Net::Server::Multiplex::MUX=HASH(0x555e9ee94dd8)', 'IO::Multiplex=HASH(0x555e9ee7b728)', 'Net::Server::Proto::TCP=GLOB(0x555e9ee94f58)', 'SCALAR(0x555e9ee9c080)') called at /usr/share/perl5/vendor_perl/IO/Multiplex.pm line 659?IO::Multiplex::loop('IO::Multiplex=HASH(0x555e9ee7b728)', 'CODE(0x555e9df12f38)') called at /usr/share/perl5/vendor_perl/Net/Server/Multiplex.pm line 71?Net::Server::Multiplex::loop('postfwd3::server=HASH(0x555e9d598d48)') called at /usr/share/perl5/vendor_perl/Net/Server.pm line 58?Net::Server::run('postfwd3::server=HASH(0x555e9d598d48)') called at /usr/sbin/postfwd3 line 3806?postfwd3::server::spawn_daemon('server') called at /usr/sbin/postfwd3 line 3714?

postfwd-geoip-antispam_1  | [postfwd3/policy][10][LOG crit]: FATAL: No record found for IP address 192.0.2.15??Trace begun at /usr/local/share/perl5/site_perl/GeoIP2/Database/Reader.pm line 89?GeoIP2::Database::Reader::_model_for_address('GeoIP2::Database::Reader=HASH(0x555e9ec3f3e0)', 'Country', 'type_check', 'Regexp=REGEXP(0x555e9ef18650)', 'ip', 192.0.2.15) called at /usr/local/share/perl5/site_perl/GeoIP2/Database/Reader.pm line 133?GeoIP2::Database::Reader::country('GeoIP2::Database::Reader=HASH(0x555e9ec3f3e0)', 'ip', 192.0.2.15) called at /etc/postfwd/postfwd-anti-spam.plugin line 245?eval {...} at /etc/postfwd/postfwd-anti-spam.plugin line 244?postfwd3::server::geoip_country_code(192.0.2.15) called at /etc/postfwd/postfwd-anti-spam.plugin line 376?postfwd3::server::__ANON__('HASH(0x555e9d709378)') called at /usr/sbin/postfwd3 line 1855?postfwd3::server::postfwd_items('HASH(0x555e9d709378)') called at /usr/sbin/postfwd3 line 2853?postfwd3::server::smtpd_access_policy(undef, 'HASH(0x555e9d709378)') called at /usr/sbin/postfwd3 line 3309?postfwd3::server::process_input(undef, 'Net::Server::Proto::TCP=GLOB(0x555e9ee95510)', '', 'HASH(0x555e9d709378)') called at /usr/sbin/postfwd3 line 3292?postfwd3::server::mux_input('Net::Server::Multiplex::MUX=HASH(0x555e9e4beba8)', 'IO::Multiplex=HASH(0x555e9ee7b728)', 'Net::Server::Proto::TCP=GLOB(0x555e9ee95510)', 'SCALAR(0x555e9ee9c428)') called at /usr/share/perl5/vendor_perl/Net/Server/Multiplex.pm line 220?Net::Server::Multiplex::MUX::mux_input('Net::Server::Multiplex::MUX=HASH(0x555e9e4beba8)', 'IO::Multiplex=HASH(0x555e9ee7b728)', 'Net::Server::Proto::TCP=GLOB(0x555e9ee95510)', 'SCALAR(0x555e9ee9c428)') called at /usr/share/perl5/vendor_perl/IO/Multiplex.pm line 659?IO::Multiplex::loop('IO::Multiplex=HASH(0x555e9ee7b728)', 'CODE(0x555e9df12f38)') called at /usr/share/perl5/vendor_perl/Net/Server/Multiplex.pm line 71?Net::Server::Multiplex::loop('postfwd3::server=HASH(0x555e9d598d48)') called at /usr/share/perl5/vendor_perl/Net/Server.pm line 58?Net::Server::run('postfwd3::server=HASH(0x555e9d598d48)') called at /usr/sbin/postfwd3 line 3806?postfwd3::server::spawn_daemon('server') called at /usr/sbin/postfwd3 line 3714?

postfwd-geoip-antispam_1  | [postfwd3/policy][10][LOG crit]: FATAL: The IP address you provided (500.0.2.15) is not a valid IPv4 or IPv6 address at /usr/local/lib/perl5/site_perl/MaxMind/DB/Reader/XS.pm line 56.?
```

Those should be caught in eval block, but somehow it escapes. In the end it doesn't fail the code. They could be mitigated by using whitelist on private IP ranges.