### PR TITLE
IPv6 support

### DIFF
--- a/conf/anti-spam-sql-st.conf
+++ b/conf/anti-spam-sql-st.conf
@@ -1,6 +1,6 @@
 create_table_st =             "CREATE TABLE IF NOT EXISTS postfwd_logins ( \
                                sasl_username varchar(100), \
-                               ip_address varchar(16), \
+                               ip_address varchar(45), \
                                state_code varchar(4), \
                                login_count int, \
                                last_login timestamp \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -40,6 +40,7 @@ RUN    apk --no-cache update \
              GeoIP2::Database::Reader \
              Class::XSAccessor \
              MaxMind::DB::Reader::XS --force \
+             Data::Validate::IP \
     && apk del make \
                wget \
                gcc \

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,6 +1,7 @@
 # Supported tags and respective `Dockerfile` links
 
 * [`latest` (Dockerfile)](https://github.com/Vnet-as/postfwd-anti-geoip-spam-plugin/blob/master/docker/Dockerfile)
+* [`v2.0.0` (Dockerfile)](https://github.com/Vnet-as/postfwd-anti-geoip-spam-plugin/blob/v2.0.0/docker/Dockerfile)
 * [`v1.50.0` (Dockerfile)](https://github.com/Vnet-as/postfwd-anti-geoip-spam-plugin/blob/v1.50.0/docker/Dockerfile)
 * [`v1.40` (Dockerfile)](https://github.com/Vnet-as/postfwd-anti-geoip-spam-plugin/blob/v1.40/docker/Dockerfile)
 * [`v1.30` (Dockerfile)](https://github.com/Vnet-as/postfwd-anti-geoip-spam-plugin/blob/v1.30/docker/Dockerfile)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,40 @@
 
 This changelog notes changes between versions of Postfwd GeoIP Anti-Spam plugin.
 
+## Version 2.0.0 [3. October 2021]
+
+Add IPv6 support for GeoIP2 databases.
+
+This is a feature that was [requested and meant to be included for a long time](https://github.com/Vnet-as/postfwd-anti-geoip-spam-plugin/issues/12), but the revision of code was always postponed.
+
+This release is tagged as `2.0.0` because IPv6 support in this plugin requires some breaking changes. The database must be dropped and recreated (or left to be created by plugin) because IPv6 addresses are longer than IPv4 addresses and the `ip_address` column had size of `varchar(16)`. With this change the column will be expanded to 45 characters.
+
+Note: Dropping the database is nothing major in this project as it only serves as cache. Altering the database schema or doing migrations would complicate code.
+
+There is one new dependency - `Data::Validate::IP` - that will make the IP address validation easier and more consistent than using regexes. It will test for valid IPv4 or IPv6 address, but also test if IP address is public. Since GeoIP databases can work only with public addresses, the GeoIP would throw error on other than public address anyway. This will reduce load on GeoIP.
+
+If you forget to drop database, you will see error such as this in log:
+
+```bash
+[postfwd3/policy][10][LOG warning]: warning: DBD::mysql::st execute failed: Data too long for column 'ip_address' at row 1 at /etc/postfwd/postfwd-anti-spam.plugin line 411.?
+postfwd::anti-spam-plugin ERROR[10]: Data too long for column 'ip_address' at row 1
+```
+
+### Breaking changes
+
+- Resize column `ip_address` in database schema from 16 to 45 characters.
+- Add new dependency `Data::Validate::IP`.
+
+### Features / Enhancements
+
+- IPv6 support
+- Better IP address validation
+
+### Bugfixes
+
+None
+
+
 ## Version 1.50.0 [27. March 2021]
 
 GeoIP2 Feature.

--- a/docs/README.md
+++ b/docs/README.md
@@ -235,7 +235,7 @@ Plugin stores interesting statistical information in the database. To query thos
 Complete development environment with postfwd, anti-spam plugin and mysql/postgresql database configured together can be run with single command from directory `tests/`:
 - MySQL: `docker-compose -f compose-dev-mysql.yml up`
 - PostgreSQL: `docker-compose -f compose-dev-postgresql.yml up`
-- MySQL with GeoIP2: `export POSTFWD_ANTISPAM_MAIN_CONFIG_PATH=/etc/postfwd/03-dev-anti-spam-mysql-geoip2.conf docker-compose -f compose-dev-mysql.yml up`
+- MySQL with GeoIP2: `export POSTFWD_ANTISPAM_MAIN_CONFIG_PATH=/etc/postfwd/03-dev-anti-spam-mysql-geoip2.conf; docker-compose -f compose-dev-mysql.yml up`
 
 Note for overriding postfwd arguments:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,12 +27,13 @@ If you are interested in how your users got their mail accounts hacked, check ou
 
 ## Plugin Compatibility Matrix
 
-| Plugin Version | Postfwd Version          | GeoIP Version |
-| :------------- | :----------------------- | :------------ |
-| v1.50.0        | postfwd3 v2.xx           | GeoIP 1, 2    |
-| v1.40          | postfwd3 v2.xx           | GeoIP 1       |
-| v1.30          | postfwd3 v2.xx           | GeoIP 1       |
-| v1.21          | postfwd1, postfwd2 v1.xx | GeoIP 1       |
+| Plugin Version | Postfwd Version          | GeoIP Version | IP version |
+| :------------- | :----------------------- | :------------ | :--------- |
+| v2.0.0         | postfwd3 v2.xx           | GeoIP 1, 2    | IPv4, IPv6 |
+| v1.50.0        | postfwd3 v2.xx           | GeoIP 1, 2    | IPv4       |
+| v1.40          | postfwd3 v2.xx           | GeoIP 1       | IPv4       |
+| v1.30          | postfwd3 v2.xx           | GeoIP 1       | IPv4       |
+| v1.21          | postfwd1, postfwd2 v1.xx | GeoIP 1       | IPv4       |
 
 - Supported database backends are **MySQL** and **PostgreSQL**.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -45,7 +45,7 @@ Pre-built ready-to-use Docker image is located on DockerHub and can be simply pu
 
 ```bash
 # postfwd3 tags
-docker pull lirt/postfwd-anti-geoip-spam-plugin:v1.50.0
+docker pull lirt/postfwd-anti-geoip-spam-plugin:v2.0.0
 # postfwd1, postfwd2 tags
 docker pull lirt/postfwd-anti-geoip-spam-plugin:v1.21
 ```
@@ -56,7 +56,7 @@ To run postfwd with geoip-plugin, run docker with configuration files mounted as
 docker run \
     -v </absolute/path/to/anti-spam.conf>:/etc/postfwd/anti-spam.conf \
     -v </absolute/path/to/postfwd.cf>:/etc/postfwd/postfwd.cf \
-    lirt/postfwd-anti-geoip-spam-plugin:v1.50.0
+    lirt/postfwd-anti-geoip-spam-plugin:v2.0.0
 ```
 
 This will run `postfwd2` or `postfwd3` (based on docker tag) with default arguments, reading postfwd rules file from your mounted volume file `postfwd.cf` and using anti-spam configuration from your file `anti-spam.conf`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -74,7 +74,7 @@ To install this plugin follow next steps:
 ```sql
 CREATE TABLE IF NOT EXISTS postfwd_logins (
    sasl_username varchar(100),
-   ip_address varchar(16),
+   ip_address varchar(45),
    state_code varchar(4),
    login_count int,
    last_login timestamp

--- a/docs/README.md
+++ b/docs/README.md
@@ -112,7 +112,8 @@ yum install -y 'perl(Geo::IP)' \
                'perl(LWP::Protocol::https)' \
                'perl(Class::XSAccessor)' \
                'perl(MaxMind::DB::Reader::XS)' \
-               'perl(Readonly)'
+               'perl(Readonly)' \
+               'perl(Data::Validate::IP)'
 ```
 
 #### Dependencies on Debian based distributions
@@ -134,7 +135,8 @@ apt-get install -y libgeo-ip-perl \
                    libclass-xsaccessor-perl \
                    libmaxmind-db-reader-xs-perl \
                    libgeoip2-perl \
-                   libreadonly-perl
+                   libreadonly-perl \
+                   libdata-validate-ip-perl
 ```
 
 ## Configuration

--- a/postfwd-anti-spam.plugin
+++ b/postfwd-anti-spam.plugin
@@ -1,7 +1,7 @@
 #!/usr/bin/env perl
 
 # Declare version
-our $VERSION = '1.50.0';
+our $VERSION = '2.0.0';
 
 # English module for Perl::Critic compliance
 use English qw( -no_match_vars );

--- a/postfwd-anti-spam.plugin
+++ b/postfwd-anti-spam.plugin
@@ -19,6 +19,9 @@ use Time::Piece;
 # For subnet matching and IP address validation
 use Net::Subnet;
 
+# IP validator
+use Data::Validate::IP qw(is_ip is_public_ip);
+
 # Configure default path to configuration files
 # or read them from environment variables
 my $cfg_anti_spam_path      = '/etc/postfix/anti-spam.conf';
@@ -365,10 +368,14 @@ my $last_cache_flush = time;
             return $result;
         }
 
-        # Simple regex test if string looks like IP address
-        if ( !( $client_ip =~ m/^\d{1,3}[.]\d{1,3}[.]\d{1,3}[.]\d{1,3}$/msx ) )
-        {
-            mylog_info("'$client_ip' is not a valid IP address");
+        # Validate if IP address is IPv4 or IPv6 public address
+        if (is_ip($client_ip)) {
+            if (! is_public_ip($client_ip)) {
+                mylog_info("'$client_ip' is not a public address");
+                return $result;
+            }
+        } else {
+            mylog_info("'$client_ip' is not a valid IPv4 or IPv6 address");
             return $result;
         }
 

--- a/postfwd-anti-spam.plugin
+++ b/postfwd-anti-spam.plugin
@@ -395,7 +395,7 @@ my $last_cache_flush = time;
             return $result;
         }
 
-        # Check how many rows was returned (0 or more)
+        # Check how many rows were returned (0 or more)
         my $row_count = $check_row_existence_sth->fetchrow_array;
         if ( $check_row_existence_sth->err ) {
             mylog_err( $check_row_existence_sth->errstr );

--- a/postfwd-anti-spam.plugin
+++ b/postfwd-anti-spam.plugin
@@ -335,7 +335,7 @@ my $last_cache_flush = time;
             ) or mylog_fatal( DBI->errstr );
         }
 
-        # Clear old records after flush interval expirates
+        # Clear old records after flush interval expired
         if ( ( $last_cache_flush + $config{app}{db_flush_interval} ) < time ) {
             mylog_info(
 "Removing records which are older than $config{app}{db_flush_interval}"

--- a/tests/dev-create-antispam-db.sql
+++ b/tests/dev-create-antispam-db.sql
@@ -1,6 +1,6 @@
 CREATE TABLE IF NOT EXISTS postfwd_logins (
    sasl_username varchar(100),
-   ip_address varchar(16),
+   ip_address varchar(45),
    state_code varchar(4),
    login_count int,
    last_login timestamp

--- a/tests/integration-compose-test-geoip2.sh
+++ b/tests/integration-compose-test-geoip2.sh
@@ -13,7 +13,7 @@ function send_requests {
 }
 
 
-# Valid user logging in with IP addresses from United Kingdom and Sweden
+# Valid user logging in with IPv4 and IPv6 addresses from United Kingdom and Sweden
 sasl_username="valid-user@example.com"
 valid_user_addresses=( 2.125.160.216
                        81.2.69.142
@@ -21,16 +21,21 @@ valid_user_addresses=( 2.125.160.216
                        81.2.69.192
                        89.160.20.112
                        89.160.20.128
+                       2a02:d3c0::12
+                       2a02:da40::ee02
+                       2a02:da40:0000:0000:0000:ff00:0042:8329
 )
 send_requests "$sasl_username" "valid_user_addresses"
 
 
-# User logging from IP addresses which are not in DB
+# User logging from IPv4 and IPv6 addresses which are not in DB
 sasl_username="valid-user-non-existing-ip@example.com"
 valid_user_non_existing_ip_addresses=(192.168.35.1
                                       10.1.1.1
                                       172.20.20.20
                                       192.0.2.15
+                                      ::1
+                                      2001::4444
 )
 send_requests "$sasl_username" "valid_user_non_existing_ip_addresses"
 
@@ -41,11 +46,13 @@ valid_user_invalid_ips=(my-special-ip
                         10123.1.1.1
                         172.20.20.20:1234
                         500.0.2.15
+                        2a02:da40::oo1k
+                        ::
 )
 send_requests "$sasl_username" "valid_user_invalid_ips"
 
 
-# Spam user logging in with IP addresses from 7 different countries
+# Spam user logging in with IPv4 and IPv6 addresses from 7 different countries
 # UK, US, BT, SE, CN, PH, GI
 sasl_username="spam-user1@example.com"
 spam_user1_addresses=( 2.125.160.216
@@ -55,11 +62,15 @@ spam_user1_addresses=( 2.125.160.216
                        111.235.160.1
                        202.196.224.0
                        217.65.48.0
+                       2a02:d540::a
+                       2a02:d040::15
+                       2001:252::252
+                       2a02:ffc0:500::100
 )
 send_requests "$sasl_username" "spam_user1_addresses"
 
 
-# Spam user logging in with 25 different IP addresses from SE
+# Spam user logging in with 30 different IPv4 and IPv6 addresses from SE
 sasl_username="spam-user2@example.com"
 spam_user2_addresses=( 89.160.20.128 89.160.20.129 89.160.20.130
                        89.160.20.131 89.160.20.132 89.160.20.133
@@ -69,7 +80,8 @@ spam_user2_addresses=( 89.160.20.128 89.160.20.129 89.160.20.130
                        89.160.20.143 89.160.20.144 89.160.20.145
                        89.160.20.146 89.160.20.147 89.160.20.148
                        89.160.20.149 89.160.20.150 89.160.20.151
-                       89.160.20.152
+                       89.160.20.152 2a02:ffc0::30 2a02:ffc0::31
+                       2a02:ffc0::32 2a02:ffc0::33 2a02:ffc0::34
 )
 send_requests "$sasl_username" "spam_user2_addresses"
 
@@ -95,7 +107,7 @@ if ! docker-compose -f "${script_path}/compose-dev-mysql.yml" logs postfwd-geoip
   errors+=("2")
 fi
 if ! docker-compose -f "${script_path}/compose-dev-mysql.yml" logs postfwd-geoip-antispam \
-     | grep "User spam-user2@example.com was logged from more than 20 IP addresses(2[45])"; then
+    | grep -E "User spam-user2@example.com was logged from more than 20 IP addresses\((30|29)\)"; then
   echo -e 'ERROR: User did not exceed IP address limit (20) but should!'
   errors+=("3")
 fi


### PR DESCRIPTION
Add IPv6 support for GeoIP2 databases.

This is a feature that was [requested and meant to be included for a long time](https://github.com/Vnet-as/postfwd-anti-geoip-spam-plugin/issues/12), but the revision of code was always postponed.

This release is tagged as `2.0.0` because IPv6 support in this plugin requires some breaking changes. The database must be dropped and recreated (or left to be created by plugin) because IPv6 addresses are longer than IPv4 addresses and the `ip_address` column had size of `varchar(16)`. With this change the column will be expanded to 45 characters.

Note: Dropping the database is nothing major in this project as it only serves as cache. Altering the database schema or doing migrations would complicate code.

There is one new dependency - `Data::Validate::IP` - that will make the IP address validation easier and more consistent than using regexes. It will test for valid IPv4 or IPv6 address, but also test if IP address is public. Since GeoIP databases can work only with public addresses, the GeoIP would throw error on other than public address anyway. This will reduce load on GeoIP.

If you forget to drop database, you will see error such as this in log:

```bash
[postfwd3/policy][10][LOG warning]: warning: DBD::mysql::st execute failed: Data too long for column 'ip_address' at row 1 at /etc/postfwd/postfwd-anti-spam.plugin line 411.?
postfwd::anti-spam-plugin ERROR[10]: Data too long for column 'ip_address' at row 1
```

Closes: https://github.com/Vnet-as/postfwd-anti-geoip-spam-plugin/issues/12